### PR TITLE
Return none arg

### DIFF
--- a/src/job_notifications/__init__.py
+++ b/src/job_notifications/__init__.py
@@ -24,7 +24,10 @@ def create_notifications(job_name: str,
     return notifications_obj
 
 
-def handled_exception(exceptions: Union[BaseException, Tuple[BaseException]], re_raise: Union[list, bool] = False):
+def handled_exception(
+        exceptions: Union[BaseException, Tuple[BaseException]],
+        re_raise: Union[list, bool] = False,
+        return_none: bool = False) -> Union[object, Exception, None]:
     """
     Decorator that handles any exception(s) passed as an arg and logs it. re_raise param will re-raise any of the
     exceptions the decorator handles after it has been logged. Pass True to re_raise param to re-raise all exceptions or
@@ -50,6 +53,8 @@ def handled_exception(exceptions: Union[BaseException, Tuple[BaseException]], re
                                 raise e
                     elif not isinstance(re_raise, list):
                         raise e
+                if return_none:
+                    return None
         return wrapper_exceptions
     return decorator_exceptions
 

--- a/tests/unit_tests/test_handled_exception.py
+++ b/tests/unit_tests/test_handled_exception.py
@@ -94,3 +94,16 @@ def test_handled_exception_re_raises_correct_error():
     with pytest.raises(ValueError):
         to_be_decorated()
 
+
+def test_handled_exception_return_none():
+    @handled_exception(KeyError, return_none=True)
+    def to_be_decorated():
+        raise KeyError
+
+    def here_is_the_test():
+        d = to_be_decorated()
+        return d
+
+    result = here_is_the_test()
+    assert result is None
+


### PR DESCRIPTION
Adding a `return_none` arg. This arg makes it possible for any functions that are decorated with the `handled_exception` decorator to return a `None` value if an exceptions is handled.